### PR TITLE
Add Goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,29 @@
+builds:
+  - main: ./cmd/connector/main.go
+    goos:
+      - darwin
+      - linux
+      - windows
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - "-s -w -X 'github.com/conduitio-labs/conduit-connector-google-cloudstorage.version={{ .Tag }}'"
+checksum:
+  name_template: checksums.txt
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^go.mod:'
+      - '^.github:'
+      - Merge branch

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .PHONY: build test test-integration
 
+VERSION=$(shell git describe --tags --dirty --always)
+
 build:
-	go build -o conduit-connector-google-cloudstorage cmd/connector/main.go
+	go build -ldflags "-X 'github.com/conduitio-labs/conduit-connector-google-cloudstorage.version=${VERSION}'" -o conduit-connector-google-cloudstorage cmd/connector/main.go
 
 test:
 	go test $(GOTEST_FLAGS) -v -race ./...

--- a/spec.go
+++ b/spec.go
@@ -27,13 +27,18 @@ var Connector = sdk.Connector{
 	NewDestination:   nil,
 }
 
+// version is set during the build process (i.e. the Makefile).
+// It follows Go's convention for module version, where the version
+// starts with the letter v, followed by a semantic version.
+var version = "v0.0.0-dev"
+
 // specification returns the connector's specification.
 func specification() sdk.Specification {
 	return sdk.Specification{
 		Name:        "Google Cloud Storage",
 		Summary:     "An Google Cloud Storage Source and Destination Connector for Conduit, Written in Go.",
 		Description: "Real time data transmission with google cloud storage",
-		Version:     "v0.1.0",
+		Version:     version,
 		Author:      "Santosh Kumar Gajawada",
 		SourceParams: map[string]sdk.Parameter{
 			config.ConfigKeyGCPServiceAccountKey: {


### PR DESCRIPTION
This PR adds a goreleaser github action which releases the connector when a semantic version tag is pushed.